### PR TITLE
Fixed defender's objective tracking flag carrier ID

### DIFF
--- a/maps/ff_ksour.lua
+++ b/maps/ff_ksour.lua
@@ -6,6 +6,10 @@ FLAG_RETURN_TIME = 60;
 INITIAL_ROUND_DELAY = 45;
 TEAM_SWITCH_DELAY = 4
 NUM_PHASES = 4
+
+DEFENDERS_OBJECTIVE_ONCAP = true
+DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
+DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
 -----------------------------------------------------------------------------
 
 -- sounds, right?
@@ -17,10 +21,6 @@ end
 -- startup
 function startup()
 	SetGameDescription("Invade Defend")
-	
-	DEFENDERS_OBJECTIVE_ONCAP = true
-	DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
-	DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
 	
 	-- set up team limits
 	local team = GetTeam( Team.kBlue )

--- a/maps/ff_ksour.lua
+++ b/maps/ff_ksour.lua
@@ -18,6 +18,10 @@ end
 function startup()
 	SetGameDescription("Invade Defend")
 	
+	DEFENDERS_OBJECTIVE_ONCAP = true
+	DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
+	DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
+	
 	-- set up team limits
 	local team = GetTeam( Team.kBlue )
 	team:SetPlayerLimit( 0 )
@@ -94,9 +98,8 @@ function startup()
 	flags_set_team( attackers )
 	
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
+	UpdateDefendersObjective()
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 end
 
 -- overwriting these functions so that there aren't repeat messages
@@ -105,7 +108,7 @@ function round_10secwarn() end
 
 function base_id_cap:oncapture(player, item)
 	SmartSound(player, "yourteam.flagcap", "yourteam.flagcap", "otherteam.flagcap")
---SmartSound(player, "vox.yourcap", "vox.yourcap", "vox.enemycap")
+	--SmartSound(player, "vox.yourcap", "vox.yourcap", "vox.enemycap")
 	SmartSpeak(player, "CTF_YOUCAP", "CTF_TEAMCAP", "CTF_THEYCAP")
  	SmartMessage(player, "#FF_YOUCAP", "#FF_TEAMCAP", "#FF_OTHERTEAMCAP", Color.kGreen, Color.kGreen, Color.kRed)
 
@@ -134,12 +137,10 @@ function base_id_cap:oncapture(player, item)
 		if ROUND_DELAY > 30 then AddSchedule("flag_30secwarn", ROUND_DELAY-30, flag_30secwarn) end
 		if ROUND_DELAY > 10 then AddSchedule("flag_10secwarn", ROUND_DELAY-10, flag_10secwarn) end		
 		
-		-- change objective icon
+		-- clear objective icon
 		ATTACKERS_OBJECTIVE_ENTITY = nil
-		if DEFENDERS_OBJECTIVE_ONFLAG or DEFENDERS_OBJECTIVE_ONCARRIER then DEFENDERS_OBJECTIVE_ENTITY = nil
-		else DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" ) end
+		UpdateDefendersObjective()
 		UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 		
 		setup_tobase_timer()
 		update_hud()
@@ -188,9 +189,8 @@ function switch_teams()
 	
 	-- change objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
-	DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
+	UpdateDefendersObjective()
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 	
 	-- reset the timer on points
 	AddScheduleRepeating("addpoints", PERIOD_TIME, addpoints)

--- a/maps/ff_napoli.lua
+++ b/maps/ff_napoli.lua
@@ -24,6 +24,10 @@ end
 function startup()
 	SetGameDescription("Invade Defend")
 	
+	DEFENDERS_OBJECTIVE_ONCAP = true
+	DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
+	DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
+	
 	-- set up team limits
 	local team = GetTeam( Team.kBlue )
 	team:SetPlayerLimit( 0 )
@@ -99,9 +103,8 @@ function startup()
 	flags_set_team( attackers )
 	
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
+	UpdateDefendersObjective()
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 end
 
 -- overwriting these functions so that there aren't repeat messages
@@ -143,7 +146,7 @@ end
 
 function base_id_cap:oncapture(player, item)
 	SmartSound(player, "yourteam.flagcap", "yourteam.flagcap", "otherteam.flagcap")
---SmartSound(player, "vox.yourcap", "vox.yourcap", "vox.enemycap")
+	--SmartSound(player, "vox.yourcap", "vox.yourcap", "vox.enemycap")
 	SmartSpeak(player, "CTF_YOUCAP", "CTF_TEAMCAP", "CTF_THEYCAP")
  	SmartMessage(player, "#FF_YOUCAP", "#FF_TEAMCAP", "#FF_OTHERTEAMCAP", Color.kGreen, Color.kGreen, Color.kRed)
 
@@ -189,10 +192,8 @@ function base_id_cap:oncapture(player, item)
 		
 		-- clear objective icon
 		ATTACKERS_OBJECTIVE_ENTITY = nil
-		if DEFENDERS_OBJECTIVE_ONFLAG or DEFENDERS_OBJECTIVE_ONCARRIER then DEFENDERS_OBJECTIVE_ENTITY = nil
-		else DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" ) end
+		UpdateDefendersObjective()
 		UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 		
 		setup_tobase_timer()
 		update_hud()
@@ -227,9 +228,8 @@ function switch_teams()
 	
 	-- change objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
-	DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
+	UpdateDefendersObjective()
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 	
 	-- reset the timer on points
 	AddScheduleRepeating("addpoints", PERIOD_TIME, addpoints)
@@ -421,5 +421,3 @@ end
 -- Don't want any body touching/triggering it except the detpack
 function trigger_detpackable_door:allowed( trigger_entity ) return EVENT_DISALLOWED 
 end
-
-

--- a/maps/ff_napoli.lua
+++ b/maps/ff_napoli.lua
@@ -8,6 +8,10 @@ TEAM_SWITCH_DELAY = 4
 NUM_PHASES = 3
 NONINITIAL_ROUND_DELAY = 45;
 RESPAWN_AFTER_CAP = false
+
+DEFENDERS_OBJECTIVE_ONCAP = true
+DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
+DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
 -----------------------------------------------------------------------------
 function respawnall()
 	BroadCastMessage( "Area Captured. Respawning..." )
@@ -23,10 +27,6 @@ end
 -- startup
 function startup()
 	SetGameDescription("Invade Defend")
-	
-	DEFENDERS_OBJECTIVE_ONCAP = true
-	DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
-	DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
 	
 	-- set up team limits
 	local team = GetTeam( Team.kBlue )

--- a/maps/ff_palermo.lua
+++ b/maps/ff_palermo.lua
@@ -1,20 +1,69 @@
-
 -- ff_palermo.lua
 
 -----------------------------------------------------------------------------
 -- includes
 -----------------------------------------------------------------------------
 
-IncludeScript("base_id_new");
+IncludeScript("base_id");
 IncludeScript("base_respawnturret");
 IncludeScript("base_location");
 
------------------------------------------------------------------------------
-
------------------------------------------------------------------------------
-
 function startup()
-	id_startup()
+	SetGameDescription( "Invade Defend" )
+	
+	DEFENDERS_OBJECTIVE_ONCAP = true
+	DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
+	DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
+	
+	-- set up team limits
+	local team = GetTeam( Team.kBlue )
+	team:SetPlayerLimit( 0 )
+
+	team = GetTeam( Team.kRed )
+	team:SetPlayerLimit( 0 )
+
+	team = GetTeam( Team.kYellow )
+	team:SetPlayerLimit( -1 )
+
+	team = GetTeam( Team.kGreen )
+	team:SetPlayerLimit( -1 )
+
+	-- CTF maps generally don't have civilians,
+	-- so override in map LUA file if you want 'em
+	local team = GetTeam(Team.kBlue)
+	team:SetClassLimit(Player.kCivilian, -1)
+
+	team = GetTeam(Team.kRed)
+	team:SetClassLimit(Player.kCivilian, -1)
+	
+	-- set them team names
+	SetTeamName( attackers, "Attackers" )
+	SetTeamName( defenders, "Defenders" )
+
+	-- start the timer for the points
+	AddScheduleRepeating("addpoints", PERIOD_TIME, addpoints)
+
+	setup_door_timer("start_gate", INITIAL_ROUND_DELAY)
+
+	cp1_flag.enabled = true
+	for i,v in ipairs({"cp1_flag", "cp2_flag", "cp3_flag", "cp4_flag", "cp5_flag", "cp6_flag", "cp7_flag", "cp8_flag"}) do
+		local flag = GetInfoScriptByName(v)
+		if flag then
+			flag:SetModel(_G[v].model)
+			flag:SetSkin(teamskins[attackers])
+			if i == 1 then
+				flag:Restore()
+			else
+				flag:Remove()
+			end
+		end
+	end	 
+	
+	flags_set_team( attackers )
+	
+	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
+	UpdateDefendersObjective()
+	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	
 	-- lower trigger_hurt damage in water
 	OutputEvent( "trigger_hurt", "SetDamage", "42" )
@@ -103,8 +152,6 @@ function onroundreset()
 
 	attackers_palammotypeone.team = attackers
 	attackers_palgrenadepackone.team = attackers
-
-
 end
 
 bellbutton = func_button:new({}) 

--- a/maps/ff_palermo.lua
+++ b/maps/ff_palermo.lua
@@ -16,59 +16,13 @@ DEFENDERS_OBJECTIVE_ONCAP = true
 DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
 DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
 
+-- custom startup
+local startup_base = startup
+
 function startup()
-	SetGameDescription( "Invade Defend" )
-	
-	-- set up team limits
-	local team = GetTeam( Team.kBlue )
-	team:SetPlayerLimit( 0 )
+    startup_base()
 
-	team = GetTeam( Team.kRed )
-	team:SetPlayerLimit( 0 )
-
-	team = GetTeam( Team.kYellow )
-	team:SetPlayerLimit( -1 )
-
-	team = GetTeam( Team.kGreen )
-	team:SetPlayerLimit( -1 )
-
-	-- CTF maps generally don't have civilians,
-	-- so override in map LUA file if you want 'em
-	local team = GetTeam(Team.kBlue)
-	team:SetClassLimit(Player.kCivilian, -1)
-
-	team = GetTeam(Team.kRed)
-	team:SetClassLimit(Player.kCivilian, -1)
-	
-	-- set them team names
-	SetTeamName( attackers, "Attackers" )
-	SetTeamName( defenders, "Defenders" )
-
-	-- start the timer for the points
-	AddScheduleRepeating("addpoints", PERIOD_TIME, addpoints)
-
-	setup_door_timer("start_gate", INITIAL_ROUND_DELAY)
-
-	cp1_flag.enabled = true
-	for i,v in ipairs({"cp1_flag", "cp2_flag", "cp3_flag", "cp4_flag", "cp5_flag", "cp6_flag", "cp7_flag", "cp8_flag"}) do
-		local flag = GetInfoScriptByName(v)
-		if flag then
-			flag:SetModel(_G[v].model)
-			flag:SetSkin(teamskins[attackers])
-			if i == 1 then
-				flag:Restore()
-			else
-				flag:Remove()
-			end
-		end
-	end	 
-	
-	flags_set_team( attackers )
-	
-	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	UpdateDefendersObjective()
-	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	
+    -- palermo specific stuff
 	-- lower trigger_hurt damage in water
 	OutputEvent( "trigger_hurt", "SetDamage", "42" )
 end

--- a/maps/ff_palermo.lua
+++ b/maps/ff_palermo.lua
@@ -8,12 +8,16 @@ IncludeScript("base_id");
 IncludeScript("base_respawnturret");
 IncludeScript("base_location");
 
+-----------------------------------------------------------------------------
+-- globals
+-----------------------------------------------------------------------------
+
+DEFENDERS_OBJECTIVE_ONCAP = true
+DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
+DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
+
 function startup()
 	SetGameDescription( "Invade Defend" )
-	
-	DEFENDERS_OBJECTIVE_ONCAP = true
-	DEFENDERS_OBJECTIVE_ONCARRIER = false --set to true to follow flag when carried
-	DEFENDERS_OBJECTIVE_ONFLAG = false --set to true to follow flag ALWAYS
 	
 	-- set up team limits
 	local team = GetTeam( Team.kBlue )

--- a/maps/includes/base_id.lua
+++ b/maps/includes/base_id.lua
@@ -1,7 +1,7 @@
 
 -- base_id.lua
 -- Invade / Defend gametype 
--- Edited Last: Dr.Satan - 22/12/2014
+-- Edited Last: Dr.Satan 23/12/2014
 
 -----------------------------------------------------------------------------
 -- includes
@@ -21,6 +21,9 @@ if onroundreset == nil then onroundreset = function() end end
 if FLAG_RETURN_TIME == nil then FLAG_RETURN_TIME = 60; end
 if ATTACKERS_OBJECTIVE_ENTITY == nil then ATTACKERS_OBJECTIVE_ENTITY = nil end
 if DEFENDERS_OBJECTIVE_ENTITY == nil then DEFENDERS_OBJECTIVE_ENTITY = nil end
+-- Satan: DEFENDERS_OBJECTIVE_ONCARRIER and ONFLAG set to false to keep objective on cap
+if DEFENDERS_OBJECTIVE_ONFLAG == nil then DEFENDERS_OBJECTIVE_ONFLAG = false end
+if DEFENDERS_OBJECTIVE_ONCARRIER == nil then DEFENDERS_OBJECTIVE_ONCARRIER = false end
 if TEAM_SWITCH_DELAY == nil then TEAM_SWITCH_DELAY = 2 end
 if RESPAWN_AFTER_CAP == nil then RESPAWN_AFTER_CAP = false end
 if RESPAWN_DELAY == nil then RESPAWN_DELAY = 2 end
@@ -154,6 +157,11 @@ function baseflag:ownercloak( owner_entity )
 	
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
+	-- Satan: Check to see if we want to point to flag and do stuff
+	if DEFENDERS_OBJECTIVE_ONFLAG then
+		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
+		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+	end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	
 	setup_return_timer()
@@ -179,6 +187,11 @@ function baseflag:dropitemcmd( owner_entity )
 
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
+	-- Satan: Check to see if we want to point to flag and do stuff
+	if DEFENDERS_OBJECTIVE_ONFLAG then
+		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
+		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+	end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	
 	setup_return_timer()
@@ -198,6 +211,11 @@ function baseflag:onownerforcerespawn( owner_entity )
 	
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
+	-- Satan: Check to see if we want to point to flag and do stuff
+	if DEFENDERS_OBJECTIVE_ONFLAG then
+		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
+		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+	end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 
 	update_hud()
@@ -218,6 +236,11 @@ function baseflag:onreturn( )
 
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
+	-- Satan: Check to see if we want to point to flag and do stuff
+	if DEFENDERS_OBJECTIVE_ONFLAG then
+		DEFENDERS_OBJECTIVE_ENTITY = flag
+		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+	end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	
 	destroy_return_timer()
@@ -281,7 +304,7 @@ function startup()
 	flags_set_team( attackers )
 	
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	-- Satan: Defenders should always point to the cap and NOT the flag
+	-- Satan: Defenders should point to the cap and NOT the flag to avoid tracing the flag holder 
 	DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -426,6 +449,16 @@ function base_id_flag:touch( touch_entity )
 
 			-- change objective icons
 			ATTACKERS_OBJECTIVE_ENTITY = player
+			if DEFENDERS_OBJECTIVE_ONFLAG then 
+				-- Satan: we want to target the flag ONLY when it's not being carried, so show D the cap instead 
+				DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..self.phase.."_cap" ) 
+				UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+			end
+			if DEFENDERS_OBJECTIVE_ONCARRIER then 
+				-- Satan: we want to target the flag, even if it's being carried (not suggested as D can wallhack)
+				DEFENDERS_OBJECTIVE_ENTITY = player 
+				UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+			end
 			UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 			UpdateObjectiveIcon( player, GetEntityByName( "cp"..self.phase.."_cap" ) )
 			
@@ -454,6 +487,11 @@ function base_id_flag:onownerdie( owner_entity )
 	
 	-- change objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
+	-- Satan: Check to see if we want to point to flag and do stuff
+	if DEFENDERS_OBJECTIVE_ONFLAG then
+		DEFENDERS_OBJECTIVE_ENTITY = flag
+		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+	end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	UpdateObjectiveIcon( player, nil )
 	
@@ -530,7 +568,8 @@ function base_id_cap:oncapture(player, item)
 		
 		-- clear objective icon
 		ATTACKERS_OBJECTIVE_ENTITY = nil
-		DEFENDERS_OBJECTIVE_ENTITY = nil
+		if DEFENDERS_OBJECTIVE_ONFLAG or DEFENDERS_OBJECTIVE_ONCARRIER then DEFENDERS_OBJECTIVE_ENTITY = nil
+		else DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" ) end
 		UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 		
@@ -575,7 +614,6 @@ function round_end()
 		
 		-- change objective icon
 		ATTACKERS_OBJECTIVE_ENTITY = flag
-		-- Satan: Defenders should always point to the cap and NOT the flag
 		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
 		UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -619,6 +657,10 @@ function flag_start(flagname)
 	
 	-- change objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
+	if DEFENDERS_OBJECTIVE_ONFLAG then
+		DEFENDERS_OBJECTIVE_ENTITY = flag 
+		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
+	end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	update_hud()
 end

--- a/maps/includes/base_id.lua
+++ b/maps/includes/base_id.lua
@@ -1,6 +1,7 @@
 
 -- base_id.lua
 -- Invade / Defend gametype 
+-- Edited Last: Dr.Satan - 22/12/2014
 
 -----------------------------------------------------------------------------
 -- includes
@@ -20,8 +21,6 @@ if onroundreset == nil then onroundreset = function() end end
 if FLAG_RETURN_TIME == nil then FLAG_RETURN_TIME = 60; end
 if ATTACKERS_OBJECTIVE_ENTITY == nil then ATTACKERS_OBJECTIVE_ENTITY = nil end
 if DEFENDERS_OBJECTIVE_ENTITY == nil then DEFENDERS_OBJECTIVE_ENTITY = nil end
-if DEFENDERS_OBJECTIVE_ONFLAG == nil then DEFENDERS_OBJECTIVE_ONFLAG = true end
-if DEFENDERS_OBJECTIVE_ONCARRIER == nil then DEFENDERS_OBJECTIVE_ONCARRIER = true end
 if TEAM_SWITCH_DELAY == nil then TEAM_SWITCH_DELAY = 2 end
 if RESPAWN_AFTER_CAP == nil then RESPAWN_AFTER_CAP = false end
 if RESPAWN_DELAY == nil then RESPAWN_DELAY = 2 end
@@ -155,9 +154,7 @@ function baseflag:ownercloak( owner_entity )
 	
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
-	if DEFENDERS_OBJECTIVE_ONFLAG then DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 	
 	setup_return_timer()
 	update_hud()
@@ -182,9 +179,7 @@ function baseflag:dropitemcmd( owner_entity )
 
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	if DEFENDERS_OBJECTIVE_ONFLAG then DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 	
 	setup_return_timer()
 	update_hud()
@@ -203,9 +198,7 @@ function baseflag:onownerforcerespawn( owner_entity )
 	
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	if DEFENDERS_OBJECTIVE_ONFLAG then DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 
 	update_hud()
 end
@@ -225,9 +218,7 @@ function baseflag:onreturn( )
 
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
-	if DEFENDERS_OBJECTIVE_ONFLAG then DEFENDERS_OBJECTIVE_ENTITY = flag end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 	
 	destroy_return_timer()
 	update_hud()
@@ -290,6 +281,7 @@ function startup()
 	flags_set_team( attackers )
 	
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
+	-- Satan: Defenders should always point to the cap and NOT the flag
 	DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -434,10 +426,7 @@ function base_id_flag:touch( touch_entity )
 
 			-- change objective icons
 			ATTACKERS_OBJECTIVE_ENTITY = player
-			if DEFENDERS_OBJECTIVE_ONFLAG then DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..self.phase.."_cap" ) end
-			if DEFENDERS_OBJECTIVE_ONCARRIER then DEFENDERS_OBJECTIVE_ENTITY = player end
 			UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-			UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 			UpdateObjectiveIcon( player, GetEntityByName( "cp"..self.phase.."_cap" ) )
 			
 			carried_by = player:GetName()
@@ -465,9 +454,7 @@ function base_id_flag:onownerdie( owner_entity )
 	
 	-- change objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
-	if DEFENDERS_OBJECTIVE_ONFLAG then DEFENDERS_OBJECTIVE_ENTITY = flag end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 	UpdateObjectiveIcon( player, nil )
 	
 	self.status = 2
@@ -543,8 +530,7 @@ function base_id_cap:oncapture(player, item)
 		
 		-- clear objective icon
 		ATTACKERS_OBJECTIVE_ENTITY = nil
-		if DEFENDERS_OBJECTIVE_ONFLAG or DEFENDERS_OBJECTIVE_ONCARRIER then DEFENDERS_OBJECTIVE_ENTITY = nil
-		else DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" ) end
+		DEFENDERS_OBJECTIVE_ENTITY = nil
 		UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 		
@@ -589,6 +575,7 @@ function round_end()
 		
 		-- change objective icon
 		ATTACKERS_OBJECTIVE_ENTITY = flag
+		-- Satan: Defenders should always point to the cap and NOT the flag
 		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
 		UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -632,9 +619,7 @@ function flag_start(flagname)
 	
 	-- change objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
-	if DEFENDERS_OBJECTIVE_ONFLAG then DEFENDERS_OBJECTIVE_ENTITY = flag end
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
-	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 	update_hud()
 end
 function flag_30secwarn() BroadCastMessage("#AD_30SecReturn") end

--- a/maps/includes/base_id.lua
+++ b/maps/includes/base_id.lua
@@ -1,7 +1,6 @@
 
 -- base_id.lua
 -- Invade / Defend gametype 
--- Edited Last: Dr.Satan 23/12/2014
 
 -----------------------------------------------------------------------------
 -- includes
@@ -21,7 +20,7 @@ if onroundreset == nil then onroundreset = function() end end
 if FLAG_RETURN_TIME == nil then FLAG_RETURN_TIME = 60; end
 if ATTACKERS_OBJECTIVE_ENTITY == nil then ATTACKERS_OBJECTIVE_ENTITY = nil end
 if DEFENDERS_OBJECTIVE_ENTITY == nil then DEFENDERS_OBJECTIVE_ENTITY = nil end
--- Satan: DEFENDERS_OBJECTIVE_ONCARRIER and ONFLAG set to false to keep objective on cap
+-- DEFENDERS_OBJECTIVE_ONCARRIER and ONFLAG set to false to keep objective on cap
 if DEFENDERS_OBJECTIVE_ONFLAG == nil then DEFENDERS_OBJECTIVE_ONFLAG = false end
 if DEFENDERS_OBJECTIVE_ONCARRIER == nil then DEFENDERS_OBJECTIVE_ONCARRIER = false end
 if TEAM_SWITCH_DELAY == nil then TEAM_SWITCH_DELAY = 2 end
@@ -157,7 +156,7 @@ function baseflag:ownercloak( owner_entity )
 	
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
-	-- Satan: Check to see if we want to point to flag and do stuff
+	-- Check to see if we want to point to flag and do stuff
 	if DEFENDERS_OBJECTIVE_ONFLAG then
 		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -187,7 +186,7 @@ function baseflag:dropitemcmd( owner_entity )
 
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	-- Satan: Check to see if we want to point to flag and do stuff
+	-- Check to see if we want to point to flag and do stuff
 	if DEFENDERS_OBJECTIVE_ONFLAG then
 		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -211,7 +210,7 @@ function baseflag:onownerforcerespawn( owner_entity )
 	
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	-- Satan: Check to see if we want to point to flag and do stuff
+	-- Check to see if we want to point to flag and do stuff
 	if DEFENDERS_OBJECTIVE_ONFLAG then
 		DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" ) 
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -236,7 +235,7 @@ function baseflag:onreturn( )
 
 	-- objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
-	-- Satan: Check to see if we want to point to flag and do stuff
+	-- Check to see if we want to point to flag and do stuff
 	if DEFENDERS_OBJECTIVE_ONFLAG then
 		DEFENDERS_OBJECTIVE_ENTITY = flag
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -304,7 +303,7 @@ function startup()
 	flags_set_team( attackers )
 	
 	ATTACKERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_flag" )
-	-- Satan: Defenders should point to the cap and NOT the flag to avoid tracing the flag holder 
+	-- Defenders should point to the cap and NOT the flag to avoid tracing the flag holder 
 	DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..phase.."_cap" )
 	UpdateTeamObjectiveIcon( GetTeam(attackers), ATTACKERS_OBJECTIVE_ENTITY )
 	UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
@@ -450,12 +449,12 @@ function base_id_flag:touch( touch_entity )
 			-- change objective icons
 			ATTACKERS_OBJECTIVE_ENTITY = player
 			if DEFENDERS_OBJECTIVE_ONFLAG then 
-				-- Satan: we want to target the flag ONLY when it's not being carried, so show D the cap instead 
+				-- we want to target the flag ONLY when it's not being carried, so show D the cap instead 
 				DEFENDERS_OBJECTIVE_ENTITY = GetEntityByName( "cp"..self.phase.."_cap" ) 
 				UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 			end
 			if DEFENDERS_OBJECTIVE_ONCARRIER then 
-				-- Satan: we want to target the flag, even if it's being carried (not suggested as D can wallhack)
+				-- we want to target the flag, even if it's being carried (not suggested as D can wallhack)
 				DEFENDERS_OBJECTIVE_ENTITY = player 
 				UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )
 			end
@@ -487,7 +486,7 @@ function base_id_flag:onownerdie( owner_entity )
 	
 	-- change objective icon
 	ATTACKERS_OBJECTIVE_ENTITY = flag
-	-- Satan: Check to see if we want to point to flag and do stuff
+	-- Check to see if we want to point to flag and do stuff
 	if DEFENDERS_OBJECTIVE_ONFLAG then
 		DEFENDERS_OBJECTIVE_ENTITY = flag
 		UpdateTeamObjectiveIcon( GetTeam(defenders), DEFENDERS_OBJECTIVE_ENTITY )


### PR DESCRIPTION
Removed DEFENDERS_OBJECTIVE_ONFLAG and DEFENDERS_OBJECTIVE_ONCARRIER and all associated updates/calls from base_id.lua
	- defenders objective should point to cap always to avoid tracing the flag carrier 
fortressforever/fortressforever#58