### PR TITLE
Don't crash if class_info() is called on non-luabind objects

### DIFF
--- a/maps/includes/base.lua
+++ b/maps/includes/base.lua
@@ -49,6 +49,20 @@ end
 
 
 -----------------------------------------------------------------------------
+-- make luabind's class_info function safer
+-- (don't crash if class_info() is called on non-luabind objects)
+-----------------------------------------------------------------------------
+local class_info_base = class_info
+class_info = function(obj)
+	local obj_type = type(obj)
+	if obj_type == "userdata" and getmetatable(obj).__luabind_class then
+		return class_info_base(obj)
+	end
+	return {}
+end
+
+
+-----------------------------------------------------------------------------
 -- reset everything
 -----------------------------------------------------------------------------
 function RespawnAllPlayers()


### PR DESCRIPTION
 * See https://github.com/luabind/luabind/commit/2c6c9054e3f9ae00498fc2b56331a17b590ab74e
 * Depends on fortressforever/fortressforever#139