### PR TITLE
Fix weapon dropdown having the wrong name

### DIFF
--- a/resource/ui/FFOptionsSubCrosshairs.res
+++ b/resource/ui/FFOptionsSubCrosshairs.res
@@ -500,10 +500,10 @@
 		"border"		"DepressedBorder"
 		"scaleImage"		"1"
 	}
-	"weapon"
+	"Crosshair"
 	{
 		"ControlName"		"ComboBox"
-		"fieldName"		"Weapon"
+		"fieldName"		"Crosshair"
 		"xpos"		"292"
 		"ypos"		"23"
 		"wide"		"150"


### PR DESCRIPTION
 * Contributes towards fortressforever/fortressforever#142