### PR TITLE
Fix "use global crosshair for all" checkbox label getting cut off

### DIFF
--- a/resource/ui/FFOptionsSubCrosshairs.res
+++ b/resource/ui/FFOptionsSubCrosshairs.res
@@ -429,7 +429,7 @@
 		"xpos"		"275"
 		"ypos"		"49"
 		"wide"		"185"
-		"tall"		"24"
+		"tall"		"32"
 		"autoResize"		"0"
 		"pinCorner"		"0"
 		"visible"		"1"
@@ -439,7 +439,7 @@
 		"textAlignment"		"west"
 		"dulltext"		"0"
 		"brighttext"		"0"
-		"wrap"		"0"
+		"wrap"		"1"
 		"Default"		"0"
 	}
 	"innerDisplay"


### PR DESCRIPTION
Contributes towards fortressforever/fortressforever#142