### PR TITLE
Remove `name "WhenFFwillOut"` to make way for Steam Friends name as the default

### DIFF
--- a/cfg/config_default.cfg
+++ b/cfg/config_default.cfg
@@ -66,5 +66,4 @@ cl_updaterate "66"
 con_enable 1
 //cl_interp "0.03"
 
-name			"WhenFFwillOut"
 


### PR DESCRIPTION
 * See fortressforever/fortressforever#172