### PR TITLE
Remove unused DamageRadius keys from PL/RPG weapon scripts

### DIFF
--- a/scripts/ff_weapon_pipelauncher.txt
+++ b/scripts/ff_weapon_pipelauncher.txt
@@ -5,7 +5,6 @@ WeaponData
 	"CycleDecrement"		"1"		// Number of bullets fired per cycle
 
 	"Damage"			"108"		// Damage per burst
-	"DamageRadius"			"150"		// Radius of damage
 
 	"RecoilAmount"			"1"		// Amount of recoil
 

--- a/scripts/ff_weapon_rpg.txt
+++ b/scripts/ff_weapon_rpg.txt
@@ -5,7 +5,6 @@ WeaponData
 	"CycleDecrement"		"1"		// Number of bullets fired per cycle
 
 	"Damage"			"102"		// Damage per burst
-	"DamageRadius"			"125"		// Radius of damage
 
 	"RecoilAmount"			"1"		// Amount of recoil
 


### PR DESCRIPTION
 * Those values are defined in C++