### PR TITLE
Increase flag touch bounds a bit

### DIFF
--- a/maps/includes/base_teamplay.lua
+++ b/maps/includes/base_teamplay.lua
@@ -724,12 +724,12 @@ end
 function baseflag:hasanimation() return true end
 
 function baseflag:gettouchsize( mins, maxs )
-	mins.x = mins.x
-	mins.y = mins.y
-	maxs.x = maxs.x
-	maxs.y = maxs.y
+	mins.x = mins.x * 1.50
+	mins.y = mins.y * 1.50
+	maxs.x = maxs.x * 1.50
+	maxs.y = maxs.y * 1.50
 	mins.z = 0
-	maxs.z = maxs.z * 0.65
+	maxs.z = maxs.z * 0.80
 end
 
 function baseflag:getphysicssize( mins, maxs )


### PR DESCRIPTION
 * Height from 65% of model height to 80%
 * Width from 100% of model width to 150%
  + Stops a single SG from being able to completely block the flag, though you can still make it difficult to grab
 * See fortressforever/fortressforever#166

Flag model bounds: 26.254800796509 x 69.179306283593
Flag bounds before this change: 26.254800796509 x 45.048884835839
Flag bounds after this change: 39.382202148438 x 55.155250549316

### Before:
![flagbounds-65](https://cloud.githubusercontent.com/assets/2389051/7107573/cb51d6c2-e11d-11e4-9ca0-c5c730f0b823.jpg)

### After:
![flagbounds-80](https://cloud.githubusercontent.com/assets/2389051/7107579/cfbc7afa-e11d-11e4-9b31-e5783355c71c.jpg)