### PR TITLE
Reduce max rockets for soldier (50 -> 30) and demo (50 -> 40)

### DIFF
--- a/scripts/ff_playerclass_demoman.txt
+++ b/scripts/ff_playerclass_demoman.txt
@@ -59,7 +59,7 @@ PlayerClassData
 		"AMMO_SHELLS"		"75"
 		"AMMO_NAILS"		"50"
 		"AMMO_CELLS"		"50"
-		"AMMO_ROCKETS"		"50"
+		"AMMO_ROCKETS"		"40"
 		"AMMO_DETPACK"		"1"
 		"AMMO_MANCANNON"	"0"
 	}

--- a/scripts/ff_playerclass_soldier.txt
+++ b/scripts/ff_playerclass_soldier.txt
@@ -56,7 +56,7 @@ PlayerClassData
 		"AMMO_SHELLS"		"100"
 		"AMMO_NAILS"		"100"
 		"AMMO_CELLS"		"50"
-		"AMMO_ROCKETS"		"50"
+		"AMMO_ROCKETS"		"30"
 		"AMMO_DETPACK"		"0"
 		"AMMO_MANCANNON"	"0"
 	}


### PR DESCRIPTION
Helps https://github.com/fortressforever/fortressforever/issues/205

The idea is to encourage players to get involved in the action every now and then, giving more depth to the death bags of players killed. Any player killing enemies and collecting ammo will be unaffected by this change, but players sitting back and spamming rockets/blues endlessly will run out of ammo quicker (although still, not that quickly - soldier after he's fired 34 rockets, and demo after he's fired 46 blues).

I think we could potentially lower these numbers further (in particular for soldier), but there be other unforeseen consequences, so I think it would be good to try a small step first.

I think this will have little effect on pickup play as soldiers typically die long before they've fired 34 rockets and if they do live that long it's very likely they can pick up an ammo bag. It's possible that one demoman camping the same spot might be encouraged out to collect ammo slightly earlier (after laying 6x 8-pipe traps) but I don't think thats a bad thing.