### PR TITLE
Tweak railgun charge sounds

### DIFF
--- a/scripts/game_sounds_ff_weapons.txt
+++ b/scripts/game_sounds_ff_weapons.txt
@@ -458,7 +458,7 @@
 	"railgun.halfcharge"
 	{
 		"channel"		"CHAN_WEAPON"
-		"volume"		"VOL_NORM"
+		"volume"		"0.3"
 		"pitch"			"PITCH_NORM"
 	"CompatibilityAttenuation"	"1.0"
 		"wave"			"ambient/energy/zap8.wav"
@@ -466,10 +466,10 @@
 	"railgun.fullcharge"
 	{
 		"channel"		"CHAN_WEAPON"
-		"volume"		"VOL_NORM"
-		"pitch"			"PITCH_NORM"
+		"volume"		"0.35"
+		"pitch"			"110"
 	"CompatibilityAttenuation"	"1.0"
-		"wave"			"ambient/energy/zap9.wav"
+		"wave"			"ambient/energy/zap8.wav"
 	}
 	"railgun.overcharge"
 	{


### PR DESCRIPTION
Reduce volume, make full charge the same sound as half charge but pitched up. Sounds much cleaner.