### PR TITLE
Re-add single shotgun (now pellet gun) to pyro

### DIFF
--- a/scripts/ff_playerclass_pyro.txt
+++ b/scripts/ff_playerclass_pyro.txt
@@ -28,6 +28,7 @@ PlayerClassData
 	ArmamentsData
 	{
 		"weapon"	"ff_weapon_crowbar"
+		"weapon"	"ff_weapon_shotgun"
 		"weapon"	"ff_weapon_ic"
 		"weapon"	"ff_weapon_flamethrower"
 	}


### PR DESCRIPTION
Depends on #44, so that it's (hopefully) not as confusing to new players