### PR TITLE
Fix the spanner special hit sound getting covered up by the clang sound

### DIFF
--- a/scripts/game_sounds_ff_weapons.txt
+++ b/scripts/game_sounds_ff_weapons.txt
@@ -770,7 +770,7 @@
 	}
 	"Spanner.specialhit"
 	{
-		"channel"		"CHAN_ITEM"
+		"channel"		"CHAN_AUTO"
 		"volume"		"1.0"
 	"CompatibilityAttenuation"	"1.0"
 		"wave"			"weapons/spanner/spanner_specialhit.wav"


### PR DESCRIPTION
 * This plays when you successfully repair some amount of health/ammo of a SG/disp, but the channel made it so the clang would stop it from being heard

Not sure why I never submitted this as a PR