### PR TITLE
Remove the jumpgun from scout

### DIFF
--- a/scripts/ff_playerclass_scout.txt
+++ b/scripts/ff_playerclass_scout.txt
@@ -23,12 +23,12 @@ PlayerClassData
 	
 	"firepower"			"10" // from 1 to 100
 	
-	// Weapns to automatically equip the class with
+	// Weapons to automatically equip the class with
 	ArmamentsData
 	{
 		"weapon"	"ff_weapon_crowbar"
 		"weapon"	"ff_weapon_shotgun"
-		"weapon"	"ff_weapon_jumpgun"
+		//"weapon"	"ff_weapon_jumpgun"
 		"weapon"	"ff_weapon_nailgun"
 		"weapon"	"ff_weapon_deploymancannon"
 


### PR DESCRIPTION
Just in case we decide to do this. Would welcome feedback from competitive community here.

The original design brief for the jumpgun was to increase the visibility of movement skill in FF and showcase the scout's movement purpose to reduce the amount of new players playing scout as a DM class. It was never intended to really affect pickups and competitive play.

However, with early stats and feedback it appears that after the addition of the weapon, score per map has increased and with a 2-scout / 2-medic typical offense, the gun introduces a get-out-of-jail-free card for scouts whilst making defense a bit harder and less enjoyable.

Until we have a better design, we could simply remove it for now, whilst we decide what to do with it, potentially changing / improving it for a later patch.