### PR TITLE
Fix jetpack sound doubling when multiple pyros are jetpacking

### DIFF
--- a/scripts/game_sounds_ff_player.txt
+++ b/scripts/game_sounds_ff_player.txt
@@ -231,7 +231,7 @@
 
 	"Player.JetpackLoop"
 	{
-		"channel"		"CHAN_AUTO"
+		"channel"		"CHAN_BODY"
 		"volume"		"0.3"
 		"CompatibilityAttenuation"	"0.7"
 		"pitch"			"95,105"


### PR DESCRIPTION
 - Fixes fortressforever/fortressforever#309

---

This is ***a*** fix, but might not be the best fix; a different channel might be better as CHAN_BODY might have issues with the sound being overwritten by other sounds (fall damage, etc?). CHAN_WEAPON didn't work for me at all (jetpack sound was totally broken).