### PR TITLE
Spies can now sneak into enemy base on Canalzone 2

### DIFF
--- a/maps/includes/base_cp.lua
+++ b/maps/includes/base_cp.lua
@@ -843,7 +843,7 @@ end
 -- triggers
 -----------------------------------------------------------------------------
 
-cp_base_trigger = trigger_ff_script:new({ team = Team.kUnassigned, failtouch_message = "" })
+cp_base_trigger = trigger_ff_script:new({ team = Team.kUnassigned, failtouch_message="#FF_NOTALLOWEDDOOR", allowdisguised = true })
 
 function cp_base_trigger:allowed( allowed_entity )
 
@@ -851,6 +851,12 @@ function cp_base_trigger:allowed( allowed_entity )
 		local player = CastToPlayer( allowed_entity )
 		if player:GetTeamId() == self.team then
 			return EVENT_ALLOWED
+		end
+		
+		if self.allowdisguised then
+			if player:IsDisguised() and player:GetDisguisedTeam() == self.team then
+				return EVENT_ALLOWED
+			end
 		end
 	end
 	return EVENT_DISALLOWED
@@ -860,12 +866,12 @@ function cp_base_trigger:onfailtouch( touch_entity )
 
 	if IsPlayer( touch_entity ) then
 		local player = CastToPlayer( touch_entity )
-		BroadCastMessageToPlayer( player, failtouch_message )
+		BroadCastMessageToPlayer( player, self.failtouch_message )
 	end
 end
 
-cp_team1_door_trigger = cp_base_trigger:new({ team = TEAM1 , failtouch_message = "#FF_NOTALLOWEDDOOR" })
-cp_team2_door_trigger = cp_base_trigger:new({ team = TEAM2 , failtouch_message = "#FF_NOTALLOWEDDOOR" })
+cp_team1_door_trigger = cp_base_trigger:new({ team = TEAM1 })
+cp_team2_door_trigger = cp_base_trigger:new({ team = TEAM2 })
 
 
 -----------------------------------------------------------------------------
@@ -1616,5 +1622,3 @@ red_teleporter_cp2 = cp_team2_teleporter_cp2
 red_teleporter_cp3 = cp_team2_teleporter_cp3
 red_teleporter_cp4 = cp_team2_teleporter_cp4
 red_teleporter_cp5 = cp_team2_teleporter_cp5
-
-


### PR DESCRIPTION
* Functionality exists in base_teamplay.lua, but the "open for disguised Spies" is never used for Command Point maps. This should allow playing Canalzone 2 as intended, where you must also keep enemies Spies and Demomen from detpacking your command center.
* This was previously implemented in the upcoming [SDK 2013 MP port of Fortress Forever](https://github.com/fortressforever-2013/fortressforever2013/commit/d5f88a7250fa555dedf95e35a0144e57d574c9a3), at least a decade after the mod already was out, but we're putting it here as well.